### PR TITLE
add test to reproduce error encoding i64 numbers above 63

### DIFF
--- a/src/leb128/mod.rs
+++ b/src/leb128/mod.rs
@@ -290,4 +290,19 @@ mod tests {
         assert_eq!(written, 1);
         assert_eq!(output, vec![input]);
     }
+
+    fn roundtrip(input: i64) {
+        let mut output = Vec::new();
+        encode_signed(input, &mut output).unwrap();
+        let (remaining, actual): (&[u8], i64) = parse_signed(&mut output).unwrap();
+
+        assert_eq!(remaining, &[]);
+        assert_eq!(actual, input);
+    }
+
+    #[test]
+    fn roundtrip_signed_leb128_i64() {
+        roundtrip(63);
+        roundtrip(64);
+    }
 }


### PR DESCRIPTION
hi, first of all, thanks for your great work.

I was playing with it today and I noticed that it encodes i64 values above 63 incorrectly

added a test to reproduce the issue, not sure about the solution, maybe use https://github.com/gimli-rs/leb128 ?