### PR TITLE
fix signed leb128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm-ast"
 description = "A WebAssembly syntax model useful for generate, reading, and emitting WebAssembly code."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Miguel D. Salcedo <miguel@salcedo.cc>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,6 +17,8 @@ wasmtime = "1.0.0"
 nom = { version = "7", optional = true }
 thiserror = "1"
 wat = { version = "1", optional = true }
+quickcheck = "1.0.3"
+quickcheck_macros = "1.0.0"
 
 [features]
 default = []


### PR DESCRIPTION
This PR fixes a problem with `encode_signed` and introduces property-based testing to test encoding and decoding more thoroughly.

Using https://github.com/gimli-rs/leb128 as an example for `64`

```
❯ cargo r
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/leb128-repl`

LEB128 Read-Eval-Print-Loop!

Converts numbers to signed and unsigned LEB128 and displays the results in
base-10, hex, and binary.

> 64
# unsigned LEB128
[64]
[40]
[01000000]

# signed LEB128
[192, 0]
[c0, 0]
[11000000, 00000000]
```